### PR TITLE
Add an NCover-compatible XML report output

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,7 @@ dotnet test --no-build test/MiniCover.XUnit.Tests/MiniCover.XUnit.Tests.csproj
 dotnet test --no-build test/MiniCover.NUnit.Tests/MiniCover.NUnit.Tests.csproj
 $MiniCover uninstrument
 $MiniCover htmlreport --threshold 90 
+$MiniCover xmlreport --threshold 90
 $MiniCover report --threshold 90
 
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then

--- a/src/MiniCover/Instrumentation/Instrumenter.cs
+++ b/src/MiniCover/Instrumentation/Instrumenter.cs
@@ -87,7 +87,13 @@ namespace MiniCover.Instrumentation
 
             using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(assemblyBackupFile, new ReaderParameters { ReadSymbols = true }))
             {
-                result.AddInstrumentedAssembly(assemblyDefinition.Name.Name, Path.GetFullPath(assemblyBackupFile), Path.GetFullPath(assemblyFile), Path.GetFullPath(pdbBackupFile), Path.GetFullPath(pdbFile));
+                var instrumentedAssembly = result.AddInstrumentedAssembly(
+                    assemblyDefinition.Name.Name,
+                    Path.GetFullPath(assemblyBackupFile),
+                    Path.GetFullPath(assemblyFile),
+                    Path.GetFullPath(pdbBackupFile),
+                    Path.GetFullPath(pdbFile)
+                );
 
                 var instrumentedConstructor = typeof(InstrumentedAttribute).GetConstructors().First();
                 var instrumentedReference = assemblyDefinition.MainModule.ImportReference(instrumentedConstructor);
@@ -157,7 +163,7 @@ namespace MiniCover.Instrumentation
 
                             var instructionId = ++id;
 
-                            result.Assemblies[assemblyDefinition.Name.Name].AddInstruction(sourceRelativePath, new InstrumentedInstruction
+                            instrumentedAssembly.AddInstruction(sourceRelativePath, new InstrumentedInstruction
                             {
                                 Id = instructionId,
                                 StartLine = sequencePoint.StartLine,

--- a/src/MiniCover/Instrumentation/Uninstrumenter.cs
+++ b/src/MiniCover/Instrumentation/Uninstrumenter.cs
@@ -7,18 +7,18 @@ namespace MiniCover.Instrumentation
     {
         public static void Execute(InstrumentationResult result)
         {
-            foreach (var assembly in result.Assemblies)
+            foreach (var assembly in result.Assemblies.Values)
             {
-                if (File.Exists(assembly.Value.BackupFile))
+                if (File.Exists(assembly.BackupFile))
                 {
-                    File.Copy(assembly.Value.BackupFile, assembly.Value.File, true);
-                    File.Delete(assembly.Value.BackupFile);
+                    File.Copy(assembly.BackupFile, assembly.File, true);
+                    File.Delete(assembly.BackupFile);
                 }
 
-                if (File.Exists(assembly.Value.BackupPdbFile))
+                if (File.Exists(assembly.BackupPdbFile))
                 {
-                    File.Copy(assembly.Value.BackupPdbFile, assembly.Value.PdbFile, true);
-                    File.Delete(assembly.Value.BackupPdbFile);
+                    File.Copy(assembly.BackupPdbFile, assembly.PdbFile, true);
+                    File.Delete(assembly.BackupPdbFile);
                 }
             }
 

--- a/src/MiniCover/Instrumentation/Uninstrumenter.cs
+++ b/src/MiniCover/Instrumentation/Uninstrumenter.cs
@@ -9,16 +9,16 @@ namespace MiniCover.Instrumentation
         {
             foreach (var assembly in result.Assemblies)
             {
-                if (File.Exists(assembly.BackupFile))
+                if (File.Exists(assembly.Value.BackupFile))
                 {
-                    File.Copy(assembly.BackupFile, assembly.File, true);
-                    File.Delete(assembly.BackupFile);
+                    File.Copy(assembly.Value.BackupFile, assembly.Value.File, true);
+                    File.Delete(assembly.Value.BackupFile);
                 }
 
-                if (File.Exists(assembly.BackupPdbFile))
+                if (File.Exists(assembly.Value.BackupPdbFile))
                 {
-                    File.Copy(assembly.BackupPdbFile, assembly.PdbFile, true);
-                    File.Delete(assembly.BackupPdbFile);
+                    File.Copy(assembly.Value.BackupPdbFile, assembly.Value.PdbFile, true);
+                    File.Delete(assembly.Value.BackupPdbFile);
                 }
             }
 

--- a/src/MiniCover/Model/InstrumentationResult.cs
+++ b/src/MiniCover/Model/InstrumentationResult.cs
@@ -14,20 +14,24 @@ namespace MiniCover.Model
         public List<string> ExtraAssemblies = new List<string>();
         public Dictionary<string, InstrumentedAssembly> Assemblies = new Dictionary<string, InstrumentedAssembly>();
 
-        public void AddInstrumentedAssembly(string name, string backupFile, string file, string backupPdbFile, string pdbFile)
+        public InstrumentedAssembly AddInstrumentedAssembly(string name, string backupFile, string file, string backupPdbFile, string pdbFile)
         {
             if (Assemblies.ContainsKey(name))
             {
-                return;
+                return Assemblies[name];
             }
 
-            Assemblies.Add(name, new InstrumentedAssembly
+            var instrumentedAssembly = new InstrumentedAssembly
             {
                 BackupFile = backupFile,
                 File = file,
                 BackupPdbFile = backupPdbFile,
                 PdbFile = pdbFile
-            });
+            };
+
+            Assemblies.Add(name, instrumentedAssembly);
+
+            return instrumentedAssembly;
         }
 
         public void AddExtraAssembly(string file)

--- a/src/MiniCover/Model/InstrumentationResult.cs
+++ b/src/MiniCover/Model/InstrumentationResult.cs
@@ -12,12 +12,16 @@ namespace MiniCover.Model
         public string HitsFile { get; set; }
 
         public List<string> ExtraAssemblies = new List<string>();
-        public List<InstrumentedAssembly> Assemblies = new List<InstrumentedAssembly>();
-        public Dictionary<string, SourceFile> Files = new Dictionary<string, SourceFile>();
+        public Dictionary<string, InstrumentedAssembly> Assemblies = new Dictionary<string, InstrumentedAssembly>();
 
-        public void AddInstrumentedAssembly(string backupFile, string file, string backupPdbFile, string pdbFile)
+        public void AddInstrumentedAssembly(string name, string backupFile, string file, string backupPdbFile, string pdbFile)
         {
-            Assemblies.Add(new InstrumentedAssembly
+            if (Assemblies.ContainsKey(name))
+            {
+                return;
+            }
+
+            Assemblies.Add(name, new InstrumentedAssembly
             {
                 BackupFile = backupFile,
                 File = file,
@@ -30,16 +34,6 @@ namespace MiniCover.Model
         {
             if (!ExtraAssemblies.Contains(file))
                 ExtraAssemblies.Add(file);
-        }
-
-        public void AddInstruction(string file, InstrumentedInstruction instruction)
-        {
-            if (!Files.ContainsKey(file))
-            {
-                Files[file] = new SourceFile();
-            }
-
-            Files[file].Instructions.Add(instruction);
         }
     }
 }

--- a/src/MiniCover/Model/InstrumentedAssembly.cs
+++ b/src/MiniCover/Model/InstrumentedAssembly.cs
@@ -1,10 +1,23 @@
-﻿namespace MiniCover.Model
+﻿using System.Collections.Generic;
+
+namespace MiniCover.Model
 {
     public class InstrumentedAssembly
     {
         public string File { get; set; }
+        public Dictionary<string, SourceFile> Files = new Dictionary<string, SourceFile>();
         public string BackupFile { get; set; }
         public string PdbFile { get; set; }
         public string BackupPdbFile { get; set; }
+
+        public void AddInstruction(string file, InstrumentedInstruction instruction)
+        {
+            if (!Files.ContainsKey(file))
+            {
+                Files[file] = new SourceFile();
+            }
+
+            Files[file].Instructions.Add(instruction);
+        }
     }
 }

--- a/src/MiniCover/Model/InstrumentedInstruction.cs
+++ b/src/MiniCover/Model/InstrumentedInstruction.cs
@@ -7,6 +7,10 @@
         public int EndLine { get; set; }
         public int StartColumn { get; set; }
         public int EndColumn { get; set; }
+        public string Assembly { get; set; }
+        public string Class { get; set; }
+        public string Method { get; set; }
+        public string MethodFullName { get; set; }
         public string Instruction { get; set; }
     }
 }

--- a/src/MiniCover/Program.cs
+++ b/src/MiniCover/Program.cs
@@ -119,6 +119,29 @@ namespace MiniCover
                 });
             });
 
+            commandLineApplication.Command("xmlreport", command =>
+            {
+                command.Description = "Write an NCover-formatted XML report to folder";
+
+                var workDirOption = CreateWorkdirOption(command);
+                var coverageFileOption = CreateCoverageFileOption(command);
+                var thresholdOption = CreateThresholdOption(command);
+                var outputOption = command.Option("--output", "Output file for NCover report [default: coverage.xml]", CommandOptionType.SingleValue);
+                command.HelpOption("-h | --help");
+
+                command.OnExecute(() =>
+                {
+                    UpdateWorkingDirectory(workDirOption);
+
+                    var coverageFile = GetCoverageFile(coverageFileOption);
+                    var threshold = GetThreshold(thresholdOption);
+                    var result = LoadCoverageFile(coverageFile);
+                    var output = GetXmlReportOutput(outputOption);
+                    XmlReport.Execute(result, output, threshold);
+                    return 0;
+                });
+            });
+
             commandLineApplication.Command("reset", command =>
             {
                 command.Description = "Reset hits count";
@@ -181,6 +204,11 @@ namespace MiniCover
         private static string GetHtmlReportOutput(CommandOption outputOption)
         {
             return outputOption.Value() ?? "coverage-html";
+        }
+
+        private static string GetXmlReportOutput(CommandOption outputOption)
+        {
+            return outputOption.Value() ?? "coverage.xml";
         }
 
         private static string GetCoverageFile(CommandOption coverageFileOption)

--- a/src/MiniCover/Reports/ConsoleReport.cs
+++ b/src/MiniCover/Reports/ConsoleReport.cs
@@ -13,7 +13,14 @@ namespace MiniCover.Reports
                    ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h)).ToArray()
                    : new int[0];
 
-            var fileColumnLength = result.Files.Keys.Select(s => s.Length).Concat(new[] { 10 }).Max();
+            var files = result.Assemblies
+                .SelectMany(assembly => assembly.Value.Files)
+                .ToDictionary(
+                    x => x.Key,
+                    x => x.Value
+                );
+
+            var fileColumnLength = files.Keys.Select(s => s.Length).Concat(new[] { 10 }).Max();
 
             WriteHorizontalLine(fileColumnLength);
 
@@ -33,7 +40,7 @@ namespace MiniCover.Reports
             var totalLines = 0;
             var totalCoveredLines = 0;
 
-            foreach (var kvFile in result.Files)
+            foreach (var kvFile in files)
             {
                 var lines = kvFile.Value.Instructions
                     .SelectMany(i => Enumerable.Range(i.StartLine, i.EndLine - i.StartLine + 1))

--- a/src/MiniCover/Reports/HtmlReport.cs
+++ b/src/MiniCover/Reports/HtmlReport.cs
@@ -13,7 +13,14 @@ namespace MiniCover.Reports
                    ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h)).ToArray()
                    : new int[0];
 
-            foreach (var kvFile in result.Files)
+            var files = result.Assemblies
+                .SelectMany(assembly => assembly.Value.Files)
+                .ToDictionary(
+                    x => x.Key,
+                    x => x.Value
+                );
+
+            foreach (var kvFile in files)
             {
                 var lines = File.ReadAllLines(Path.Combine(result.SourcePath, kvFile.Key));
 

--- a/src/MiniCover/Reports/XmlReport.cs
+++ b/src/MiniCover/Reports/XmlReport.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using MiniCover.Model;
+
+namespace MiniCover.Reports
+{
+    public static class XmlReport
+    {
+        public static void Execute(InstrumentationResult result, string output, float threshold)
+        {
+            var hits = File.Exists(result.HitsFile)
+                ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h)).ToArray()
+                : new int[0];
+            
+            var data = new XProcessingInstruction("xml-stylesheet", "type='text/xsl' href='coverage.xsl'");
+            
+            var document = new XDocument(new XDeclaration("1.0", "utf-8", "yes"), data);
+            
+            var coverageElement = new XElement(
+                XName.Get("coverage"),
+                new XAttribute(XName.Get("profilerVersion"), 0),
+                new XAttribute(XName.Get("driverVersion"), 0),
+                new XAttribute(XName.Get("startTime"), DateTime.MaxValue.ToString("o")),
+                new XAttribute(XName.Get("measureTime"), DateTime.MinValue.ToString("o"))
+            );
+
+            var modules = result.Assemblies.Select(assembly =>
+            {
+                var module = new XElement(
+                    XName.Get("module"),
+                    new XAttribute(XName.Get("moduleId"), Guid.NewGuid().ToString()),
+                    new XAttribute(XName.Get("name"), assembly.Key),
+                    new XAttribute(XName.Get("assembly"), assembly.Key),
+                    new XAttribute(XName.Get("assemblyIdentity"), assembly.Key)
+                );
+
+                var methods = assembly.Value.Files.Select(file =>
+                {
+                    var hitInstructions = file.Value.Instructions.Where(h => hits.Contains(h.Id)).ToArray();
+                    
+                    return file.Value.Instructions
+                        .GroupBy(instruction => new Tuple<string, string, string>(instruction.Class, instruction.Method, instruction.MethodFullName))
+                        .Select(instruction =>
+                    {
+                        var method = new XElement(
+                            XName.Get("method"),
+                            new XAttribute(XName.Get("name"), instruction.Key.Item2),
+                            new XAttribute(XName.Get("class"), instruction.Key.Item1),
+                            new XAttribute(XName.Get("excluded"), "false"),
+                            new XAttribute(XName.Get("instrumented"), "true"),
+                            new XAttribute(XName.Get("fullname"), instruction.Key.Item3)
+                        );
+
+                        var methodPoints = instruction.Select(methodPoint =>
+                        {
+                            var hitCount = hitInstructions.Count(hit => hit.Equals(methodPoint));
+                            
+                            return new XElement(
+                                XName.Get("seqpnt"),
+                                new XAttribute(XName.Get("visitcount"), hitCount),
+                                new XAttribute(XName.Get("line"), methodPoint.StartLine),
+                                new XAttribute(XName.Get("column"), methodPoint.StartColumn),
+                                new XAttribute(XName.Get("endline"), methodPoint.EndLine),
+                                new XAttribute(XName.Get("endcolumn"), methodPoint.EndColumn),
+                                new XAttribute(XName.Get("excluded"), "false"),
+                                new XAttribute(XName.Get("document"), Path.Combine(result.SourcePath, file.Key))
+                            );
+                        });
+                        
+                        method.Add(methodPoints);
+
+                        return method;
+                    });
+                });
+                
+                module.Add(methods);
+
+                return module;
+            });
+            
+            coverageElement.Add(modules);
+            
+            document.Add(coverageElement);
+            
+            File.WriteAllText(output, document.ToString());
+        }
+    }
+}


### PR DESCRIPTION
I had to change the structure of the output coverage JSON to make this fit (so it's not compatible with previously-output coverage), but now people can use something like [ReportGenerator](https://github.com/danielpalme/ReportGenerator) to generate HTML reports :)