### PR TITLE
Allow reset command to be okay if coverage file is not there

### DIFF
--- a/src/MiniCover/Program.cs
+++ b/src/MiniCover/Program.cs
@@ -132,10 +132,17 @@ namespace MiniCover
                     UpdateWorkingDirectory(workDirOption);
 
                     var coverageFile = GetCoverageFile(coverageFileOption);
-                    var result = LoadCoverageFile(coverageFile);
+                    try
+                    {
+                        var result = LoadCoverageFile(coverageFile);
 
-                    if (File.Exists(result.HitsFile))
-                        File.Delete(result.HitsFile);
+                        if (File.Exists(result.HitsFile))
+                            File.Delete(result.HitsFile);
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        // In this case, it is ok that the file is not found.
+                    }
 
                     return 0;
                 });
@@ -234,7 +241,7 @@ namespace MiniCover
         private static InstrumentationResult LoadCoverageFile(string coverageFile)
         {
             if (!File.Exists(coverageFile))
-                throw new Exception($"Coverage file {coverageFile} doesn't exist");
+                throw new FileNotFoundException($"Coverage file {coverageFile} doesn't exist");
 
             return JsonConvert.DeserializeObject<InstrumentationResult>(File.ReadAllText(coverageFile));
         }

--- a/src/MiniCover/Program.cs
+++ b/src/MiniCover/Program.cs
@@ -132,17 +132,9 @@ namespace MiniCover
                     UpdateWorkingDirectory(workDirOption);
 
                     var coverageFile = GetCoverageFile(coverageFileOption);
-                    try
-                    {
-                        var result = LoadCoverageFile(coverageFile);
 
-                        if (File.Exists(result.HitsFile))
-                            File.Delete(result.HitsFile);
-                    }
-                    catch (FileNotFoundException)
-                    {
-                        // In this case, it is ok that the file is not found.
-                    }
+                    if (File.Exists(coverageFile))
+                        File.Delete(coverageFile);
 
                     return 0;
                 });


### PR DESCRIPTION
The reset command should not throw an exception if the coveragefile is not there. Having the reset command throw can break build pipelines that are starting from a clean pull of a project that is being instrumented.