### PR TITLE
Improved performance of report on a mid-sized project.

### DIFF
--- a/src/MiniCover/Reports/BaseReport.cs
+++ b/src/MiniCover/Reports/BaseReport.cs
@@ -11,7 +11,7 @@ namespace MiniCover.Reports
         public virtual int Execute(InstrumentationResult result, float threshold)
         {
             var hits = File.Exists(result.HitsFile)
-                               ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h)).Distinct().ToHashSet()
+                               ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h)).ToHashSet()
                                : new HashSet<int>();
 
             var files = result.Assemblies
@@ -49,8 +49,9 @@ namespace MiniCover.Reports
 
                 WriteReport(kvFile, lines, coveredLines, coveragePercentage, fileColor);
 
-                WriteDetailedReport(result, files, hits);
             }
+
+            WriteDetailedReport(result, files, hits);
 
             var totalCoveragePercentage = (float)totalCoveredLines / totalLines;
             var isHigherThanThreshold = totalCoveragePercentage >= threshold;

--- a/src/MiniCover/Reports/HtmlReport.cs
+++ b/src/MiniCover/Reports/HtmlReport.cs
@@ -56,16 +56,20 @@ namespace MiniCover.Reports
                     htmlWriter.WriteLine("<body style=\"font-family: sans-serif;\">");
 
                     var uncoveredLineNumbers = new HashSet<int>();
-                    foreach(var i in kvFile.Value.Instructions)
-                        if (!hits.Contains(i.Id))
-                            for (var lineIndex = i.StartLine; lineIndex <= i.EndLine; lineIndex++)
-                                uncoveredLineNumbers.Add(lineIndex);
-
                     var coveredLineNumbers = new HashSet<int>();
-                    foreach (var i in kvFile.Value.Instructions)
+                    foreach(var i in kvFile.Value.Instructions)
+                    {
                         if (hits.Contains(i.Id))
+                        {
                             for (var lineIndex = i.StartLine; lineIndex <= i.EndLine; lineIndex++)
                                 coveredLineNumbers.Add(lineIndex);
+                        }
+                        else
+                        {
+                            for (var lineIndex = i.StartLine; lineIndex <= i.EndLine; lineIndex++)
+                                uncoveredLineNumbers.Add(lineIndex);
+                        }
+                    }
 
                     var l = 0;
                     foreach (var line in lines)

--- a/src/MiniCover/Reports/HtmlReport.cs
+++ b/src/MiniCover/Reports/HtmlReport.cs
@@ -55,32 +55,30 @@ namespace MiniCover.Reports
                     htmlWriter.WriteLine("<html>");
                     htmlWriter.WriteLine("<body style=\"font-family: sans-serif;\">");
 
-                    var instrumentedLineNumbers = kvFile.Value.Instructions
-                        .SelectMany(i => Enumerable.Range(i.StartLine, i.EndLine - i.StartLine + 1))
-                        .Distinct()
-                        .ToArray();
+                    var uncoveredLineNumbers = new HashSet<int>();
+                    foreach(var i in kvFile.Value.Instructions)
+                        if (!hits.Contains(i.Id))
+                            for (var lineIndex = i.StartLine; lineIndex < i.EndLine; lineIndex++)
+                                uncoveredLineNumbers.Add(lineIndex);
 
-                    var hitInstructions = kvFile.Value.Instructions.Where(h => hits.Contains(h.Id)).ToArray();
-                    var coveredLineNumbers = hitInstructions
-                        .SelectMany(i => Enumerable.Range(i.StartLine, i.EndLine - i.StartLine + 1))
-                        .Distinct()
-                        .ToArray();
+                    var coveredLineNumbers = new HashSet<int>();
+                    foreach (var i in kvFile.Value.Instructions)
+                        if (hits.Contains(i.Id))
+                            for (var lineIndex = i.StartLine; lineIndex < i.EndLine; lineIndex++)
+                                coveredLineNumbers.Add(lineIndex);
 
                     var l = 0;
                     foreach (var line in lines)
                     {
                         l++;
                         var style = "white-space: pre;";
-                        if (instrumentedLineNumbers.Contains(l))
+                        if (coveredLineNumbers.Contains(l))
                         {
-                            if (coveredLineNumbers.Contains(l))
-                            {
-                                style += BgColorGreen;
-                            }
-                            else
-                            {
-                                style += BgColorRed;
-                            }
+                            style += BgColorGreen;
+                        }
+                        else if (uncoveredLineNumbers.Contains(l))
+                        {
+                            style += BgColorRed;
                         }
                         else
                         {

--- a/src/MiniCover/Reports/HtmlReport.cs
+++ b/src/MiniCover/Reports/HtmlReport.cs
@@ -58,13 +58,13 @@ namespace MiniCover.Reports
                     var uncoveredLineNumbers = new HashSet<int>();
                     foreach(var i in kvFile.Value.Instructions)
                         if (!hits.Contains(i.Id))
-                            for (var lineIndex = i.StartLine; lineIndex < i.EndLine; lineIndex++)
+                            for (var lineIndex = i.StartLine; lineIndex <= i.EndLine; lineIndex++)
                                 uncoveredLineNumbers.Add(lineIndex);
 
                     var coveredLineNumbers = new HashSet<int>();
                     foreach (var i in kvFile.Value.Instructions)
                         if (hits.Contains(i.Id))
-                            for (var lineIndex = i.StartLine; lineIndex < i.EndLine; lineIndex++)
+                            for (var lineIndex = i.StartLine; lineIndex <= i.EndLine; lineIndex++)
                                 coveredLineNumbers.Add(lineIndex);
 
                     var l = 0;


### PR DESCRIPTION
Hi,
I have improved the performance a bit more, now it runs under 5secs on riganti/dotvvm and almost all time is spent in `coverage.json` deserialization.