### PR TITLE
Change HTML report to use monospace font on source-code

### DIFF
--- a/src/MiniCover/Reports/HtmlReport.cs
+++ b/src/MiniCover/Reports/HtmlReport.cs
@@ -53,7 +53,7 @@ namespace MiniCover.Reports
                 using (var htmlWriter = (TextWriter)File.CreateText(fileName))
                 {
                     htmlWriter.WriteLine("<html>");
-                    htmlWriter.WriteLine("<body style=\"font-family: sans-serif;\">");
+                    htmlWriter.WriteLine("<body style=\"font-family: monospace;\">");
 
                     var uncoveredLineNumbers = new HashSet<int>();
                     var coveredLineNumbers = new HashSet<int>();


### PR DESCRIPTION
Fixes issue: https://github.com/lucaslorentz/minicover/issues/15

@thisisthekap, Please, let me know if this PR fixes the issue you opened.

<img width="603" alt="screen shot 2018-02-06 at 5 39 43 pm" src="https://user-images.githubusercontent.com/2268284/35880338-cf36c4c2-0b64-11e8-832c-5584894d3a95.png">
