### PR TITLE
fix #23 visual studio build and fix wrong namespaces

### DIFF
--- a/MiniCover.sln
+++ b/MiniCover.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiniCover", "src\MiniCover\MiniCover.csproj", "{CE06DCCF-32DB-44F2-B6D8-37DD0395C406}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiniCover.XUnit.Tests", "test\MiniCover.XUnit.Tests\MiniCover.XUnit.Tests.csproj", "{78E87245-EB9E-4B68-BB3C-75ED0BA4E1FC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MiniCover.NUnit.Tests", "test\MiniCover.NUnit.Tests\MiniCover.NUnit.Tests.csproj", "{01757BB0-81E7-496F-AA0C-8CB3AB4C9760}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiniCover.NUnit.Tests", "test\MiniCover.NUnit.Tests\MiniCover.NUnit.Tests.csproj", "{01757BB0-81E7-496F-AA0C-8CB3AB4C9760}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiniCover.Tests", "test\MiniCover.Tests\MiniCover.Tests.csproj", "{2D96D8D4-F62E-4A1C-B4A1-86524C7FECFB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{01757BB0-81E7-496F-AA0C-8CB3AB4C9760}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01757BB0-81E7-496F-AA0C-8CB3AB4C9760}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{01757BB0-81E7-496F-AA0C-8CB3AB4C9760}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D96D8D4-F62E-4A1C-B4A1-86524C7FECFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D96D8D4-F62E-4A1C-B4A1-86524C7FECFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D96D8D4-F62E-4A1C-B4A1-86524C7FECFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D96D8D4-F62E-4A1C-B4A1-86524C7FECFB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/MiniCover.NUnit.Tests/UnitTest1.cs
+++ b/test/MiniCover.NUnit.Tests/UnitTest1.cs
@@ -1,6 +1,7 @@
+using MiniCover.Tests;
 using NUnit.Framework;
 
-namespace MiniCover.Tests.NUnit
+namespace MiniCover.NUnit.Tests
 {
     [TestFixture]
     public class UnitTest1

--- a/test/MiniCover.XUnit.Tests/UnitTest1.cs
+++ b/test/MiniCover.XUnit.Tests/UnitTest1.cs
@@ -1,7 +1,7 @@
-using System;
+using MiniCover.Tests;
 using Xunit;
 
-namespace MiniCover.Tests
+namespace MiniCover.XUnit.Tests
 {
     public class UnitTest1
     {


### PR DESCRIPTION
#What

- Fix wrong namespaces in test files
- Add the reference to MiniCover.Tests in solution file