### PR TITLE
Fix errors when multiple assemblies points to same source file

### DIFF
--- a/src/MiniCover/Model/InstrumentationResult.cs
+++ b/src/MiniCover/Model/InstrumentationResult.cs
@@ -27,12 +27,12 @@ namespace MiniCover.Model
             ExtraAssemblies.Add(file);
         }
 
-        public Dictionary<string, SourceFile> GetSourceFiles()
+        public SortedDictionary<string, SourceFile> GetSourceFiles()
         {
-            return Assemblies
+            return new SortedDictionary<string, SourceFile>(Assemblies
                 .SelectMany(a => a.SourceFiles)
                 .GroupBy(kv => kv.Key, kv => kv.Value)
-                .ToDictionary(g => g.Key, g => SourceFile.Merge(g));
+                .ToDictionary(g => g.Key, g => SourceFile.Merge(g)));
         }
     }
 }

--- a/src/MiniCover/Model/InstrumentationResult.cs
+++ b/src/MiniCover/Model/InstrumentationResult.cs
@@ -26,5 +26,13 @@ namespace MiniCover.Model
         {
             ExtraAssemblies.Add(file);
         }
+
+        public Dictionary<string, SourceFile> GetSourceFiles()
+        {
+            return Assemblies
+                .SelectMany(a => a.SourceFiles)
+                .GroupBy(kv => kv.Key, kv => kv.Value)
+                .ToDictionary(g => g.Key, g => SourceFile.Merge(g));
+        }
     }
 }

--- a/src/MiniCover/Model/SourceFile.cs
+++ b/src/MiniCover/Model/SourceFile.cs
@@ -1,9 +1,18 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace MiniCover.Model
 {
     public class SourceFile
     {
+        public static SourceFile Merge(IEnumerable<SourceFile> sources)
+        {
+            return new SourceFile
+            {
+                Instructions = sources.SelectMany(s => s.Instructions).ToList()
+            };
+        }
+
         public List<InstrumentedInstruction> Instructions = new List<InstrumentedInstruction>();
     }
 }

--- a/src/MiniCover/Reports/BaseReport.cs
+++ b/src/MiniCover/Reports/BaseReport.cs
@@ -11,15 +11,10 @@ namespace MiniCover.Reports
         public virtual int Execute(InstrumentationResult result, float threshold)
         {
             var hits = File.Exists(result.HitsFile)
-                               ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h)).ToHashSet()
-                               : new HashSet<int>();
+                ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h)).ToHashSet()
+                : new HashSet<int>();
 
-            var files = result.Assemblies
-                .SelectMany(assembly => assembly.SourceFiles)
-                .ToDictionary(
-                    x => x.Key,
-                    x => x.Value
-                );
+            var files = result.GetSourceFiles();
 
             SetFileColumnLength(files.Keys.Select(s => s.Length).Concat(new[] { 10 }).Max());
 


### PR DESCRIPTION
@HigorCesar 
This solves report problems when 2 binary different assemblies generated from same source files.

But besides this solution I would like to improve the coverage.json file, maybe move source files to json root, as a sibling of assemblers field.