### PR TITLE
Potential fix for NuGet push failing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,5 +17,5 @@ $MiniCover report --threshold 90
 
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
 	dotnet pack src/MiniCover -c Release --output $PWD/artifacts --version-suffix ci-`date +%Y%m%d%H%M%S`
-	dotnet nuget push artifacts/* -k $NUGET_KEY -s https://www.nuget.org/api/v2/package
+	dotnet nuget push artifacts/*.nupkg -k $NUGET_KEY -s https://api.nuget.org/v3/index.json
 fi


### PR DESCRIPTION
TravisCI reported that the build failed recently because pushing the NuGet package timed out:
```
Microsoft (R) Build Engine version 15.3.409.57025 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.
  MiniCover -> /home/travis/build/lucaslorentz/minicover/src/MiniCover/bin/Release/netcoreapp2.0/dotnet-minicover.dll
  Successfully created package '/home/travis/build/lucaslorentz/minicover/artifacts/MiniCover.2.0.0-ci-20180214071708.nupkg'.
info : Pushing MiniCover.2.0.0-ci-20180214071708.nupkg to 'https://www.nuget.org/api/v2/package'...
info :   PUT https://www.nuget.org/api/v2/package/
error: A task was canceled.
error:   Pushing took too long. You can change the default timeout of 300 seconds by using the --timeout <seconds> option with the push command.
The command "./build.sh" exited with 1.
Done. Your build exited with 1.
```

This PR updates the build script to push to NuGet using v3 of their API and match only .nupkg files for pushing.