### PR TITLE
Hits now has a count and a fast mode: save at the end.

### DIFF
--- a/src/MiniCover/Instrumentation/Instrumenter.cs
+++ b/src/MiniCover/Instrumentation/Instrumenter.cs
@@ -145,6 +145,10 @@ namespace MiniCover.Instrumentation
                 var hitMethodInfo = typeof(HitService).GetMethod("Hit");
                 var hitMethodReference = assemblyDefinition.MainModule.ImportReference(hitMethodInfo);
 
+                var endMethodInfo = typeof(HitService).GetMethod("End");
+                var endMethodReference = assemblyDefinition.MainModule.ImportReference(endMethodInfo);
+
+
                 var methods = assemblyDefinition.GetAllMethods();
 
                 var documentsGroups = methods
@@ -162,6 +166,11 @@ namespace MiniCover.Instrumentation
                     var sourceRelativePath = GetSourceRelativePath(documentGroup.Key.Url);
                     if (sourceRelativePath == null)
                         continue;
+
+                    bool isSourceInstrumented = true;
+                    if (!sourceFiles.Contains(documentGroup.Key.Url))
+                        isSourceInstrumented = false;
+
 
                     if (documentGroup.Key.FileHasChanged())
                     {
@@ -211,7 +220,10 @@ namespace MiniCover.Instrumentation
                                 Instruction = instruction.ToString()
                             });
 
-                            InstrumentInstruction(instructionId, instruction, hitMethodReference, methodGroup.Key, ilProcessor);
+                            if (isSourceInstrumented)
+                                InstrumentInstruction(instructionId, instruction, hitMethodReference, methodGroup.Key, ilProcessor);
+                            else
+                                InstrumentInstruction(instructionId, instruction, endMethodReference, methodGroup.Key, ilProcessor);
                         }
 
                         ilProcessor.Body.OptimizeMacros();

--- a/src/MiniCover/Reports/BaseReport.cs
+++ b/src/MiniCover/Reports/BaseReport.cs
@@ -11,7 +11,7 @@ namespace MiniCover.Reports
         public virtual int Execute(InstrumentationResult result, float threshold)
         {
             var hits = File.Exists(result.HitsFile)
-                ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h)).ToHashSet()
+                ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h.Split(' ')[0])).ToHashSet()
                 : new HashSet<int>();
 
             var files = result.GetSourceFiles();

--- a/src/MiniCover/Reports/OpenCoverReport.cs
+++ b/src/MiniCover/Reports/OpenCoverReport.cs
@@ -12,7 +12,7 @@ namespace MiniCover.Reports
         public static void Execute(InstrumentationResult result, string output, float threshold)
         {
             var hits = File.Exists(result.HitsFile)
-                ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h)).ToArray()
+                ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h.Split(' ')[0])).ToArray()
                 : new int[0];
             int fileIndex = 0;   
             int sequencePointMegaCounter = 0;

--- a/src/MiniCover/Reports/XmlReport.cs
+++ b/src/MiniCover/Reports/XmlReport.cs
@@ -11,7 +11,7 @@ namespace MiniCover.Reports
         public static void Execute(InstrumentationResult result, string output, float threshold)
         {
             var hits = File.Exists(result.HitsFile)
-                ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h)).ToArray()
+                ? File.ReadAllLines(result.HitsFile).Select(h => int.Parse(h.Split(' ')[0])).ToArray()
                 : new int[0];
 
             var data = new XProcessingInstruction("xml-stylesheet", "type='text/xsl' href='coverage.xsl'");


### PR DESCRIPTION
Good night, 

This is a big step, I will understand if you have some concers to merge it.

Two ideas
- The hit file will have the id and number of repetitions, this decrease heavily the hit file size (in my case from >400Mb to few Kb)
- Save the hit file when has to be save (just at the end).

and when is saved?

Two possibilities:
- slow: source indicated by parameters cover everything, so instrumenter will be like Init - Hit - Hit... in this case, nothing changes, every hit is saved in each hit call.
- fast: source indicated by parameters cover some dlls, other's aren't covered (the test dll or third party), so instrumenter will mark with 'hit' the sources dll's, and with 'end' the others. Now the test will be Init - End - Hit - Hit - hit... End, so in the End will be a save, in hits just recorded in a dictionary. Even in throw scenarios will work (because the test always will assert).

Some boolean has to be used to control when a fast or slow control we are (the build.sh is in slow, but my project is in fast.
I have a /src folder and a /test  folder at the same level, so my unit testing are outside.

sonarqube continue working with that, and the build.sh exactly the same.

PD: the issue about instrument outside dll's, as I explain, are used here!
PD2: using the stacktrace works but is slow.