### PR TITLE
Remove leading dots and slashes from HTML report file names

### DIFF
--- a/src/MiniCover/Reports/HtmlReport.cs
+++ b/src/MiniCover/Reports/HtmlReport.cs
@@ -4,6 +4,7 @@ using MiniCover.Model;
 using System.IO;
 using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace MiniCover.Reports
 {
@@ -32,7 +33,7 @@ namespace MiniCover.Reports
         protected override void WriteReport(KeyValuePair<string, SourceFile> kvFile, int lines, int coveredLines, float coveragePercentage, ConsoleColor color)
         {
             _htmlReport.AppendLine("<tr>");
-            _htmlReport.AppendLine($"<td><a href=\"{kvFile.Key}.html\">{kvFile.Key}</a></td>");
+            _htmlReport.AppendLine($"<td><a href=\"{GetHtmlFileName(kvFile.Key)}\">{kvFile.Key}</a></td>");
             _htmlReport.AppendLine($"<td>{lines}</td>");
             _htmlReport.AppendLine($"<td>{coveredLines}</td>");
             _htmlReport.AppendLine($"<td style=\"{GetBgColor(color)}\">{coveragePercentage:P}</td>");
@@ -45,7 +46,7 @@ namespace MiniCover.Reports
             {
                 var lines = File.ReadAllLines(Path.Combine(result.SourcePath, kvFile.Key));
 
-                var fileName = Path.Combine(_output, kvFile.Key + ".html");
+                var fileName = GetHtmlFileName(kvFile.Key);
 
                 Directory.CreateDirectory(Path.GetDirectoryName(fileName));
 
@@ -152,6 +153,12 @@ namespace MiniCover.Reports
                 default:
                     throw new ArgumentException($"Invalid color: {color}");
             }
+        }
+
+        private string GetHtmlFileName(string fileName)
+        {
+            string safeName = Regex.Replace(fileName, @"^[./\\]+", "");
+            return Path.Combine(_output, safeName + ".html");
         }
     }
 }


### PR DESCRIPTION
Instrumenting with --sources "../proj/**/*.cs" causes filenames to be "../proj/src/Foo.cs" and the subsequent HTML report to spill out of coverage-html/ (e.g. coverage-html/../proj/src/Foo.cs)

This fixes that.