### PR TITLE
Sort opencover report by sourceline, sonarqube do strange things if not.

### DIFF
--- a/src/MiniCover/Reports/OpenCoverReport.cs
+++ b/src/MiniCover/Reports/OpenCoverReport.cs
@@ -89,7 +89,9 @@ namespace MiniCover.Reports
 
                                 int sequencePointMiniCounter = 0;
 
-                                var sequencePoints = method.Select(methodPoint =>
+                                var sequencePoints = method
+                                    .OrderBy(methodPoint => methodPoint.StartLine)
+                                    .Select(methodPoint =>
                                 {
                                     var hitCount = hitInstructions.Count(hit => hit.Equals(methodPoint));
 


### PR DESCRIPTION
Hi,

Just a small fix, looking sonarqube coverage it appear some linear lines hitted, other not hitted in strange patterns. Sonarqube seems to need the report sorted by sourceline. Now it's working better.