### PR TITLE
adding configdir option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ opencovercoverage.xml
 bin
 obj
 .vs
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ dotnet build
 cd tools
 
 # Instrument assemblies inside 'test' folder to detect hits for source files inside 'src' folder
-dotnet minicover instrument --workdir ../ --assemblies test/**/bin/**/*.dll --sources src/**/*.cs 
+dotnet minicover instrument --configdir ~/out --workdir ../ --assemblies test/**/bin/**/*.dll --sources src/**/*.cs 
 
 # Reset hits count in case minicover was run for this project
 dotnet minicover reset
@@ -75,14 +75,14 @@ for project in test/**/*.csproj; do dotnet test --no-build $project; done
 cd tools
 
 # Uninstrument assemblies, it's important if you're going to publish or deploy build outputs
-dotnet minicover uninstrument --workdir ../
+dotnet minicover uninstrument --configdir ~/out --workdir ../
 
 # Create html reports inside folder coverage-html
-dotnet minicover htmlreport --workdir ../ --threshold 90
+dotnet minicover htmlreport --configdir ~/out --workdir ../ --threshold 90
 
 # Print console report
 # This command returns failure if the coverage is lower than the threshold
-dotnet minicover report --workdir ../ --threshold 90
+dotnet minicover report --configdir ~/out --workdir ../ --threshold 90
 
 cd ..
 ```


### PR DESCRIPTION
to separate between workdir (used as parent dir for instrumentation files and used as configuration files target dir, this would allow calling instrument while passing root as working dir and absolute paths for the include/exclude assemblies and source code args)