### PR TITLE
adding parent dir option to instrument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ opencovercoverage.xml
 bin
 obj
 .vs
+.DS_Store

--- a/src/MiniCover/Program.cs
+++ b/src/MiniCover/Program.cs
@@ -227,16 +227,6 @@ namespace MiniCover
             return Directory.GetCurrentDirectory();
         }
 
-        private static string UpdateWorkingDirectory(CommandOption workDirOption1, string currentDir) {
-            if (workDirOption1.HasValue())
-            {
-                var fullWorkDir = Path.GetFullPath(workDirOption1.Value());
-                Directory.SetCurrentDirectory(fullWorkDir);
-            } else {
-                Directory.SetCurrentDirectory(currentDir);
-            }
-            return Directory.GetCurrentDirectory();
-        }
         private static CommandOption CreateThresholdOption(CommandLineApplication command)
         {
             return command.Option("--threshold", "Coverage percentage threshold (default: 90)", CommandOptionType.SingleValue);


### PR DESCRIPTION
to separate between workdir (used as parent dir for instrumentation files and used as configuration files target dir, this would allow calling instrument while passing root as working dir and absolute paths for the include/exclude assemblies and source code args)