### PR TITLE
fixed counting packages and files for clover report

### DIFF
--- a/src/MiniCover/Reports/Clover/CloverReport.cs
+++ b/src/MiniCover/Reports/Clover/CloverReport.cs
@@ -150,11 +150,11 @@ namespace MiniCover.Reports.Clover
         {
             return result.Assemblies
                 .Select(t => CountPackageMetrics(t, hits))
-                .Aggregate((prev, next) =>
+                .Aggregate(new CloverCounter(), (counter, next) =>
                 {
-                    prev.Add(next);
-                    prev.Packages += 1;
-                    return prev;
+                    counter.Add(next);
+                    counter.Packages += 1;
+                    return counter;
                 });;
         }
 
@@ -162,11 +162,11 @@ namespace MiniCover.Reports.Clover
         {
             return assembly.SourceFiles
                 .Select(t => CountFileMetrics(t.Value, hits))
-                .Aggregate((prev, next) =>
+                .Aggregate(new CloverCounter(), (counter, next) =>
                 {
-                    prev.Add(next);
-                    prev.Files += 1;
-                    return prev;
+                    counter.Add(next);
+                    counter.Files += 1;
+                    return counter;
                 });
         }
 


### PR DESCRIPTION
The counter worked incorrectly if the list contains 1 item