### PR TITLE
Quick fix for Wrong Test method with last Nunit3TestAdapter #57

### DIFF
--- a/src/MiniCover.HitServices/TestMethodUtils.cs
+++ b/src/MiniCover.HitServices/TestMethodUtils.cs
@@ -9,7 +9,7 @@ namespace MiniCover.HitServices
 {
     public static class TestMethodUtils
     {
-        private static readonly IEnumerable<string> TestFrameworkAssemblies = new[]
+        private static readonly HashSet<string> TestFrameworkAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "NUnit3.TestAdapter",
             "nunit.framework",
@@ -20,7 +20,7 @@ namespace MiniCover.HitServices
             "Microsoft.VisualStudio.TestPlatform.MSTest.TestAdpater",
             "Microsoft.VisualStudio.TestPlatform.TestFramework"
         };
-        private static readonly Dictionary<string, bool> AssemblyHasPdbCache = new Dictionary<string, bool>();
+        private static readonly Dictionary<string, bool> IsProjectAssemblyCache = new Dictionary<string, bool>();
         private static readonly object Lock = new object();
         public static MethodBase GetTestMethod()
         {
@@ -43,16 +43,16 @@ namespace MiniCover.HitServices
             
             lock (Lock)
             {
-                if (AssemblyHasPdbCache.TryGetValue(location, out var hasPdb)) return hasPdb;
-                hasPdb = IsNotATestFrameworkAssembly(methodBase.DeclaringType.Assembly) && File.Exists(Path.ChangeExtension(location, ".pdb"));
-                AssemblyHasPdbCache.Add(location, hasPdb);
-                return hasPdb;
+                if (IsProjectAssemblyCache.TryGetValue(location, out var isProjectAssembly)) return isProjectAssembly;
+                isProjectAssembly = IsNotATestFrameworkAssembly(methodBase.DeclaringType.Assembly) && File.Exists(Path.ChangeExtension(location, ".pdb"));
+                IsProjectAssemblyCache.Add(location, isProjectAssembly);
+                return isProjectAssembly;
             }
         }
 
         private static bool IsNotATestFrameworkAssembly(Assembly assembly)
         {
-            return !TestFrameworkAssemblies.Any(framework => assembly.GetName().Name.Equals(framework, StringComparison.InvariantCultureIgnoreCase));
+            return !TestFrameworkAssemblies.Contains(assembly.GetName().Name);
         }
     }
 }

--- a/src/MiniCover.HitServices/TestMethodUtils.cs
+++ b/src/MiniCover.HitServices/TestMethodUtils.cs
@@ -1,12 +1,25 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace MiniCover.HitServices
 {
     public static class TestMethodUtils
     {
+        private static readonly IEnumerable<string> TestFrameworkAssemblies = new[]
+        {
+            "NUnit3.TestAdapter",
+            "nunit.framework",
+            "xunit.core",
+            "xunit.execution.dotnet",
+            "Microsoft.TestPlatform.Core.Utilities",
+            "Microsoft.TestPlatform.CrossPlatEngine",
+            "Microsoft.VisualStudio.TestPlatform.MSTest.TestAdpater",
+            "Microsoft.VisualStudio.TestPlatform.TestFramework"
+        };
         private static readonly Dictionary<string, bool> AssemblyHasPdbCache = new Dictionary<string, bool>();
         private static readonly object Lock = new object();
         public static MethodBase GetTestMethod()
@@ -31,10 +44,15 @@ namespace MiniCover.HitServices
             lock (Lock)
             {
                 if (AssemblyHasPdbCache.TryGetValue(location, out var hasPdb)) return hasPdb;
-                hasPdb = File.Exists(Path.ChangeExtension(location, ".pdb"));
+                hasPdb = IsNotATestFrameworkAssembly(methodBase.DeclaringType.Assembly) && File.Exists(Path.ChangeExtension(location, ".pdb"));
                 AssemblyHasPdbCache.Add(location, hasPdb);
                 return hasPdb;
             }
+        }
+
+        private static bool IsNotATestFrameworkAssembly(Assembly assembly)
+        {
+            return !TestFrameworkAssemblies.Any(framework => assembly.GetName().Name.Equals(framework, StringComparison.InvariantCultureIgnoreCase));
         }
     }
 }

--- a/tests/MiniCover.HitServices.UnitTests/MiniCover.HitServices.UnitTests.csproj
+++ b/tests/MiniCover.HitServices.UnitTests/MiniCover.HitServices.UnitTests.csproj
@@ -8,6 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tests/MiniCover.HitServices.UnitTests/TestMethodUtilsMsTests.cs
+++ b/tests/MiniCover.HitServices.UnitTests/TestMethodUtilsMsTests.cs
@@ -1,11 +1,12 @@
-﻿using Shouldly;
-using Xunit;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
 
 namespace MiniCover.HitServices.UnitTests
 {
-    public class TestMethodUtilsTests
+    [TestClass]
+    public class TestMethodUtilsMsTests
     {
-        [Fact]
+        [TestMethod]
         public void TestMethodUtil_ReturnTestMethod()
         {
             var method = TestMethodUtils.GetTestMethod();

--- a/tests/MiniCover.HitServices.UnitTests/TestMethodUtilsNunitTests.cs
+++ b/tests/MiniCover.HitServices.UnitTests/TestMethodUtilsNunitTests.cs
@@ -1,0 +1,15 @@
+﻿using NUnit.Framework;
+using Shouldly;
+
+namespace MiniCover.HitServices.UnitTests
+{
+    public class TestMethodUtilsNunitTests
+    {
+        [Test]
+        public void TestMethodUtil_ReturnTestMethod()
+        {
+            var method = TestMethodUtils.GetTestMethod();
+            method.Name.ShouldBe(nameof(TestMethodUtil_ReturnTestMethod));
+        }
+    }
+}

--- a/tests/MiniCover.HitServices.UnitTests/TestMethodUtilsXUnitTests.cs
+++ b/tests/MiniCover.HitServices.UnitTests/TestMethodUtilsXUnitTests.cs
@@ -1,0 +1,15 @@
+﻿using Shouldly;
+using Xunit;
+
+namespace MiniCover.HitServices.UnitTests
+{
+    public class TestMethodUtilsXUnitTests
+    {
+        [Fact]
+        public void TestMethodUtil_ReturnTestMethod()
+        {
+            var method = TestMethodUtils.GetTestMethod();
+            method.Name.ShouldBe(nameof(TestMethodUtil_ReturnTestMethod));
+        }
+    }
+}


### PR DESCRIPTION
As I wrote it in the issue we should do a small instrumentation on Test assemblies that would add an attribute on hit so that we don't need to know tests frameworks
Also would improve execution as then we don't need to instrument every thing with the try catch only the Test assemblies