### PR TITLE
Fix wrong reporting of coverage for lambda expression.

### DIFF
--- a/src/MiniCover/Reports/Coveralls/CoverallsReport.cs
+++ b/src/MiniCover/Reports/Coveralls/CoverallsReport.cs
@@ -117,10 +117,14 @@ namespace MiniCover.Reports.Coveralls
 
                 var sourceLines = File.ReadAllLines(sourceFile);
 
+                /*
                 var hitsPerLine = kvFile.Value.Instructions
                     .SelectMany(i => i.GetLines(), (instruction, line) => new { instruction, line })
                     .GroupBy(i => i.line)
                     .ToDictionary(g => g.Key, g => g.Sum(j => hits.GetInstructionHitCount(j.instruction.Id)));
+                */
+
+                CoverLine[] covlines = BaseReport.GetCovLines(hits, kvFile, sourceFile);
 
                 var fileName = Path.GetRelativePath(_rootFolder, sourceFile).Replace("\\", "/");
 
@@ -130,8 +134,8 @@ namespace MiniCover.Reports.Coveralls
                     SourceDigest = ComputeSourceDigest(sourceFile),
                     Coverage = Enumerable.Range(1, sourceLines.Length).Select(line =>
                     {
-                        return hitsPerLine.ContainsKey(line)
-                            ? hitsPerLine[line]
+                        return (null != covlines[line])
+                            ? covlines[line].Hits
                             : default(int?);
                     }).ToArray()
                 };

--- a/src/MiniCover/Reports/Coveralls/CoverallsReport.cs
+++ b/src/MiniCover/Reports/Coveralls/CoverallsReport.cs
@@ -132,7 +132,7 @@ namespace MiniCover.Reports.Coveralls
                 {
                     Name = fileName,
                     SourceDigest = ComputeSourceDigest(sourceFile),
-                    Coverage = Enumerable.Range(1, sourceLines.Length).Select(line =>
+                    Coverage = Enumerable.Range(0, (sourceLines.Length - 1)).Select(line =>
                     {
                         return (null != covlines[line])
                             ? covlines[line].Hits


### PR DESCRIPTION
Lambda expression are included in both the creation statement and the execution statement. The current implementation consider the code executed when just the creation of the lambda expression is hit.
The modified code look at which instruction is  a sub-instruction and look for a hit in the sub-instruction.
I have create a side by side test here: https://ci.appveyor.com/project/aseduto/testman