### PR TITLE
check directory exists before enumerate files

### DIFF
--- a/src/MiniCover/HitServices/HitsInfo.cs
+++ b/src/MiniCover/HitServices/HitsInfo.cs
@@ -50,11 +50,14 @@ namespace MiniCover
         {
             var contexts = new List<HitContext>();
 
-            foreach (var hitFile in Directory.GetFiles(path, "*.hits"))
+            if (Directory.Exists(path))
             {
-                using (var fileStream = File.Open(hitFile, FileMode.Open, FileAccess.Read))
+                foreach (var hitFile in Directory.GetFiles(path, "*.hits"))
                 {
-                    contexts.AddRange(HitContext.Deserialize(fileStream));
+                    using (var fileStream = File.Open(hitFile, FileMode.Open, FileAccess.Read))
+                    {
+                        contexts.AddRange(HitContext.Deserialize(fileStream));
+                    }
                 }
             }
 


### PR DESCRIPTION
- MiniCover 3.0.4
- OS: gitlab CI runner on debian image
- installed as a global tool with `dotnet tool install -g MiniCover`

Please make sure the change makes a sense. May be there is another case why the directory `coverage-hits` didn't exists after `minicover reset`

Unhandled exception occured:

```
...
$ minicover reset
...
$ dotnet test
...
$ minicover uninstrument
Changing working directory to "/builds/bla/MyProject"
$ minicover report --threshold 0
Changing working directory to "/builds/bla/MyProject"

Unhandled Exception: System.IO.DirectoryNotFoundException: Could not find a part of the path '/builds/bla/MyProject/coverage-hits'.
   at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
   at System.IO.Enumeration.FileSystemEnumerator`1..ctor(String directory, EnumerationOptions options)
   at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options)
   at System.IO.Enumeration.FileSystemEnumerableFactory.UserFiles(String directory, String expression, EnumerationOptions options)
   at System.IO.Directory.InternalEnumeratePaths(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
   at MiniCover.HitsInfo.TryReadFromDirectory(String path) in /home/vsts/work/1/s/src/MiniCover/HitServices/HitsInfo.cs:line 53
   at MiniCover.Reports.BaseReport.Execute(InstrumentationResult result, Single threshold)
   at MiniCover.CommandLine.Commands.ConsoleReportCommand.Execute() in /home/vsts/work/1/s/src/MiniCover/CommandLine/Commands/ConsoleReportCommand.cs:line 35
   at Microsoft.Extensions.CommandLineUtils.CommandLineApplication.<>c__DisplayClass79_0.<OnExecute>b__0()
   at Microsoft.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
   at MiniCover.Program.Main(String[] args) in /home/vsts/work/1/s/src/MiniCover/Program.cs:line 57
/bin/bash: line 161:   674 Aborted                 (core dumped) minicover report --threshold 0
ERROR: Job failed: exit code 1
```