### PR TITLE
fix: send coverallsreport bad request 400

### DIFF
--- a/src/MiniCover.Reports/Coveralls/CoverallsReport.cs
+++ b/src/MiniCover.Reports/Coveralls/CoverallsReport.cs
@@ -151,8 +151,13 @@ namespace MiniCover.Reports.Coveralls
 
             using (var client = new HttpClient())
             {
-                using (var formData = new MultipartFormDataContent())
+                var boundary = Guid.NewGuid().ToString();
+
+                using (var formData = new MultipartFormDataContent(boundary))
                 {
+                    formData.Headers.Remove("Content-Type");
+                    formData.Headers.TryAddWithoutValidation("Content-Type", $"multipart/form-data; boundary={boundary}");
+
                     formData.Add(stringContent, "json_file", "coverage.json");
 
                     var response = await client.PostAsync(coverallsJobsUrl, formData);


### PR DESCRIPTION
Sending report ends with BadRequest 400 error

```
<head>
<title>400 Bad Request</title>
</head>
<body>
<center><h1>400 Bad Request</h1></center>
<hr><center>nginx</center>
</body>
</html>
```