### PR TITLE
Workaround: no instrumentation for C# 9 init-only properties.

### DIFF
--- a/src/MiniCover.Core/Instrumentation/MethodInstrumenter.cs
+++ b/src/MiniCover.Core/Instrumentation/MethodInstrumenter.cs
@@ -43,6 +43,11 @@ namespace MiniCover.Core.Instrumentation
         {
             var originalMethod = methodDefinition.ResolveOriginalMethod();
 
+            if (methodDefinition.MethodReturnType.ReturnType.IsRequiredModifier)
+            {
+                return;
+            }
+
             var instrumentedMethod = instrumentedAssembly.GetOrAddMethod(
                 originalMethod.DeclaringType.FullName,
                 originalMethod.Name,

--- a/tests/MiniCover.Core.UnitTests/Instrumentation/PropInit.cs
+++ b/tests/MiniCover.Core.UnitTests/Instrumentation/PropInit.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using FluentAssertions;
+
+namespace MiniCover.Core.UnitTests.Instrumentation
+{
+    public class PropInit : BaseTest
+    {
+        public class Class
+        {
+            public int Value { get; init; }
+        }
+
+        public PropInit() : base(typeof(Class).GetProperties().First().GetSetMethod())
+        {
+        }
+
+        public override void FunctionalTest()
+        {
+            var result = new Class { Value = 5 };
+            result.Value.Should().Be(5);
+        }
+    }
+}

--- a/tests/MiniCover.Core.UnitTests/Instrumentation/PropSet.cs
+++ b/tests/MiniCover.Core.UnitTests/Instrumentation/PropSet.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using FluentAssertions;
+
+namespace MiniCover.Core.UnitTests.Instrumentation
+{
+    public class PropSet : BaseTest
+    {
+        public class Class
+        {
+            public int Value { get; set; }
+        }
+
+        public PropSet() : base(typeof(Class).GetProperties().First().GetSetMethod())
+        {
+        }
+
+        public override void FunctionalTest()
+        {
+            var result = new Class { Value = 5 };
+            result.Value.Should().Be(5);
+        }
+    }
+}


### PR DESCRIPTION
This is workaround for #152.