### PR TITLE
Fix IOException caused by unreleased file locks

### DIFF
--- a/src/MiniCover.Core/Instrumentation/AssemblyInstrumenter.cs
+++ b/src/MiniCover.Core/Instrumentation/AssemblyInstrumenter.cs
@@ -40,7 +40,7 @@ namespace MiniCover.Core.Instrumentation
         {
             var assemblyDirectory = assemblyFile.Directory;
 
-            var resolver = ActivatorUtilities.CreateInstance<CustomAssemblyResolver>(_serviceProvider, assemblyDirectory);
+            using var resolver = ActivatorUtilities.CreateInstance<CustomAssemblyResolver>(_serviceProvider, assemblyDirectory);
 
             _logger.LogTrace("Assembly resolver search directories: {directories}", [resolver.GetSearchDirectories()]);
 


### PR DESCRIPTION
I can reproduce the same issue as described in #172 (see last [comment](https://github.com/lucaslorentz/minicover/issues/172#issuecomment-2586901226)) on slower build agents with 3.8.0.

`CustomAssemblyResolver` is disposable but its instance is never disposed. I'm not sure about all the consequences but I have never seen the problem again after adding the `using` statement.