### PR TITLE
fix: count clover conditional coverage

### DIFF
--- a/src/MiniCover.Reports/Clover/CloverReport.cs
+++ b/src/MiniCover.Reports/Clover/CloverReport.cs
@@ -182,11 +182,20 @@ namespace MiniCover.Reports.Clover
             var localInstructions = instructions.ToArray();
             var coveredInstructions = localInstructions
                 .Where(instruction => hits.WasHit(instruction.HitId)).ToArray();
+            var allConditionals = localInstructions
+                .SelectMany(instruction => instruction.Conditions)
+                .SelectMany(condition => condition.Branches)
+                .ToArray();
+            var coveredConditionals = allConditionals
+                .Where(branch => hits.WasHit(branch.HitId))
+                .ToArray();
 
             return new CloverCounter
             {
                 Statements = localInstructions.Length,
                 CoveredStatements = coveredInstructions.Length,
+                Conditionals = allConditionals.Length,
+                CoveredConditionals = coveredConditionals.Length,
                 Methods = localInstructions
                     .GroupBy(instruction => instruction.Method.FullName)
                     .Count(),

--- a/tests/MiniCover.Reports.UnitTests/Clover/CloverReportTests.cs
+++ b/tests/MiniCover.Reports.UnitTests/Clover/CloverReportTests.cs
@@ -1,0 +1,102 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
+using MiniCover.Core.Hits;
+using MiniCover.Core.Model;
+using MiniCover.HitServices;
+using MiniCover.Reports.Clover;
+using MiniCover.Reports.UnitTests.TestHelpers;
+using Moq;
+using Xunit;
+
+namespace MiniCover.Reports.UnitTests.Clover
+{
+    public class CloverReportTests : TestBase
+    {
+        [Fact]
+        public void Execute_ShouldIncludeConditionalMetricsFromBranches()
+        {
+            var method = new InstrumentedMethod
+            {
+                Class = "Sample.Feature",
+                Name = "Run",
+                FullName = "Sample.Feature.Run()"
+            };
+
+            var assembly = new InstrumentedAssembly("Sample");
+            assembly.AddSequence("src/Sample.cs", new InstrumentedSequence
+            {
+                HitId = 10,
+                StartLine = 42,
+                EndLine = 42,
+                StartColumn = 1,
+                EndColumn = 10,
+                Method = method,
+                Conditions =
+                [
+                    new InstrumentedCondition
+                    {
+                        Branches =
+                        [
+                            new InstrumentedBranch { HitId = 11 },
+                            new InstrumentedBranch { HitId = 12 }
+                        ]
+                    }
+                ]
+            });
+
+            var result = new InstrumentationResult
+            {
+                SourcePath = "/repo",
+                HitsPath = "/repo/coverage-hits"
+            };
+            result.AddInstrumentedAssembly(assembly);
+
+            var hits = new HitsInfo(
+            [
+                new HitContext(
+                    "Tests",
+                    "Sample.Tests",
+                    "Run",
+                    new Dictionary<int, int>
+                    {
+                        { 10, 1 },
+                        { 11, 1 }
+                    })
+            ]);
+
+            var hitsReader = MockFor<IHitsReader>();
+            hitsReader.Setup(reader => reader.TryReadFromDirectory(result.HitsPath)).Returns(hits);
+
+            var sut = new CloverReport(hitsReader.Object);
+            var outputPath = Path.GetTempFileName();
+            var fileSystem = new FileSystem();
+
+            try
+            {
+                sut.Execute(result, fileSystem.FileInfo.New(outputPath));
+
+                var document = XDocument.Load(outputPath);
+                var metrics = document
+                    .Descendants("metrics")
+                    .First();
+
+                metrics.Attribute("statements")!.Value.Should().Be("1");
+                metrics.Attribute("coveredstatements")!.Value.Should().Be("1");
+                metrics.Attribute("conditionals")!.Value.Should().Be("2");
+                metrics.Attribute("coveredconditionals")!.Value.Should().Be("1");
+                metrics.Attribute("methods")!.Value.Should().Be("1");
+                metrics.Attribute("coveredmethods")!.Value.Should().Be("1");
+                metrics.Attribute("elements")!.Value.Should().Be("4");
+                metrics.Attribute("coveredelements")!.Value.Should().Be("3");
+            }
+            finally
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fix Clover report conditional metrics so `conditionals` and `coveredconditionals` are populated from instrumented branches instead of always remaining `0`.

## Root Cause
`CloverReport.CountMetrics(...)` counted statements and methods, but never counted condition branches even though branch data was already present in `InstrumentedSequence.Conditions[].Branches[]`.

## Changes
- count conditional branches and covered conditional branches in the Clover metrics aggregator
- add a regression test for Clover report metrics at the report layer

## Validation
- `dotnet test tests/MiniCover.Reports.UnitTests/MiniCover.Reports.UnitTests.csproj --filter CloverReportTests`
- `dotnet test MiniCover.sln`
- full before/after repro on the sample project using a locally packed tool build

## Before / After Repro
Using the same `sample` project flow (`pack -> tool restore -> build -> reset -> instrument -> test -> cloverreport`):

Before on `upstream/master`:
- project metrics: `conditionals="0" coveredconditionals="0"`
- `AnotherClass.cs`: `conditionals="0" coveredconditionals="0"`

After on this branch:
- project metrics: `conditionals="12" coveredconditionals="10"`
- `AnotherClass.cs`: `conditionals="6" coveredconditionals="4"`
